### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(mINI LANGUAGES CXX)
+
+add_library(mINI INTERFACE)
+add_library(mINI::mINI ALIAS mINI)
+
+target_include_directories(mINI SYSTEM INTERFACE src)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  include(CTest)
+endif()
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB_RECURSE mINITestsSRC *.cpp)
+
+foreach(src ${mINITestsSRC})
+  get_filename_component(filename ${src} NAME)
+  string(REPLACE ".cpp" "" tgt ${filename})
+  add_executable(${tgt} ${src})
+  target_include_directories(${tgt} PRIVATE lest)
+  target_link_libraries(${tgt} PRIVATE mINI::mINI)
+  add_test(NAME ${tgt} COMMAND ${tgt})
+endforeach()


### PR DESCRIPTION
This PR adds CMake support for mINI and it's tests.

E.g. example of adding mINI to another CMake project by directly fetching it from github:
```CMake
FetchContent_Declare(
  mINI
  GIT_REPOSITORY https://github.com/pulzed/mINI.git
  GIT_PROGRESS TRUE)
FetchContent_MakeAvailable(mINI)
target_link_libraries(MyTarget PRIVATE mINI::mINI)
```

Or build and run tests using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html):
```sh
❯ cmake -Bbuild
-- The CXX compiler identification is GNU 11.1.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/vinci/Develop/VSCode/mINI/build
```

```sh
❯ cmake --build build -j 12
[  7%] Building CXX object tests/CMakeFiles/testhuge.dir/testhuge.cpp.o
[ 28%] Building CXX object tests/CMakeFiles/testgenerate.dir/testgenerate.cpp.o
[ 35%] Building CXX object tests/CMakeFiles/testcasesens.dir/testcasesens.cpp.o
[ 35%] Building CXX object tests/CMakeFiles/testwrite.dir/testwrite.cpp.o
[ 35%] Building CXX object tests/CMakeFiles/testread.dir/testread.cpp.o
[ 42%] Building CXX object tests/CMakeFiles/testutf8.dir/testutf8.cpp.o
[ 50%] Building CXX object tests/CMakeFiles/testcopy.dir/testcopy.cpp.o
[ 57%] Linking CXX executable testcopy
[ 64%] Linking CXX executable testhuge
[ 71%] Linking CXX executable testcasesens
[ 71%] Built target testcopy
[ 71%] Built target testhuge
[ 71%] Built target testcasesens
[ 78%] Linking CXX executable testutf8
[ 85%] Linking CXX executable testgenerate
[ 85%] Built target testutf8
[ 85%] Built target testgenerate
[ 92%] Linking CXX executable testread
[100%] Linking CXX executable testwrite
[100%] Built target testread
[100%] Built target testwrite
```

```sh
❯ make test
Running tests...
Test project /home/vinci/Develop/VSCode/mINI/build
    Start 1: testcasesens
1/7 Test #1: testcasesens .....................   Passed    0.00 sec
    Start 2: testcopy
2/7 Test #2: testcopy .........................   Passed    0.00 sec
    Start 3: testgenerate
3/7 Test #3: testgenerate .....................   Passed    0.00 sec
    Start 4: testhuge
4/7 Test #4: testhuge .........................   Passed    0.05 sec
    Start 5: testread
5/7 Test #5: testread .........................   Passed    0.00 sec
    Start 6: testutf8
6/7 Test #6: testutf8 .........................   Passed    0.00 sec
    Start 7: testwrite
7/7 Test #7: testwrite ........................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) =   0.07 sec
```

For ... reasons (:roll_eyes:) make all must be run prior to make test. [see here](https://stackoverflow.com/questions/733475/cmake-ctest-make-test-doesnt-build-tests)