### PR TITLE
INIMap: Add User-Declared Copy Assignment Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mINI <img align="left" src="icon.png?raw=true" height="96">
 
-v0.9.14
+v0.9.15
 
 ## Info
 

--- a/src/mini/ini.h
+++ b/src/mini/ini.h
@@ -23,7 +23,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-//  /mINI/ v0.9.14
+//  /mINI/ v0.9.15
 //  An INI file reader and writer for the modern age.
 //
 ///////////////////////////////////////////////////////////////////////////////
@@ -156,7 +156,11 @@ namespace mINI
 
 		INIMap() { }
 
-		INIMap(INIMap const& other)
+		INIMap(INIMap const& other) : dataIndexMap(other.dataIndexMap), data(other.data)
+		{
+		}
+
+		INIMap& operator=(INIMap const& other)
 		{
 			std::size_t data_size = other.data.size();
 			for (std::size_t i = 0; i < data_size; ++i)
@@ -166,6 +170,7 @@ namespace mINI
 				data.emplace_back(key, obj);
 			}
 			dataIndexMap = T_DataIndexMap(other.dataIndexMap);
+			return *this;
 		}
 
 		T& operator[](std::string key)


### PR DESCRIPTION
Hi,

I've Been Using Your Library For My DOS Utility Collection [MabelDOS](https://github.com/MabelMedia-LLC/MabelDOS) For Some Time Now, And I've Just Enabled Verbose Warnings Under G++ And It Gave A Few Warnings About Missing Explicit CAO Operators Being Deprecated.

I've Gone Ahead And Added One, So You Can Use `-Wall` And `-Wextra` Without Any Warnings Showing Up.

Thanks!

P.S: I've Bumped The Minor Version Number To Signify A Bug Fix.
P.P.S: All Read/Write Tests Pass With `lest`.