### PR TITLE
Fixed reading/writing files with non-ASCII characters in the path on windows.

### DIFF
--- a/src/mini/ini.h
+++ b/src/mini/ini.h
@@ -94,6 +94,12 @@
 #include <sys/stat.h>
 #include <cctype>
 
+#ifdef _WIN32
+typedef std::wstring mINIFilePath;
+#else
+typedef std::string mINIFilePath;
+#endif
+
 namespace mINI
 {
 	namespace INIStringUtil
@@ -394,7 +400,7 @@ namespace mINI
 		}
 
 	public:
-		INIReader(std::string const& filename, bool keepLineData = false)
+		INIReader(mINIFilePath const& filename, bool keepLineData = false)
 		{
 			fileReadStream.open(filename, std::ios::in | std::ios::binary);
 			if (keepLineData)
@@ -453,7 +459,7 @@ namespace mINI
 	public:
 		bool prettyPrint = false;
 
-		INIGenerator(std::string const& filename)
+		INIGenerator(mINIFilePath filename)
 		{
 			fileWriteStream.open(filename, std::ios::out | std::ios::binary);
 		}
@@ -519,7 +525,7 @@ namespace mINI
 		using T_LineData = std::vector<std::string>;
 		using T_LineDataPtr = std::shared_ptr<T_LineData>;
 
-		std::string filename;
+		mINIFilePath filename;
 
 		T_LineData getLazyOutput(T_LineDataPtr const& lineData, INIStructure& data, INIStructure& original)
 		{
@@ -680,7 +686,7 @@ namespace mINI
 	public:
 		bool prettyPrint = false;
 
-		INIWriter(std::string const& filename)
+		INIWriter(mINIFilePath const& filename)
 		: filename(filename)
 		{
 		}
@@ -688,8 +694,14 @@ namespace mINI
 
 		bool operator<<(INIStructure& data)
 		{
+#ifdef _WIN32
+			struct _stat64i32 buf;
+			bool fileExists = (_wstat(filename.c_str(), &buf) == 0);
+#else
 			struct stat buf;
 			bool fileExists = (stat(filename.c_str(), &buf) == 0);
+#endif
+
 			if (!fileExists)
 			{
 				INIGenerator generator(filename);
@@ -746,10 +758,10 @@ namespace mINI
 	class INIFile
 	{
 	private:
-		std::string filename;
+		mINIFilePath filename;
 
 	public:
-		INIFile(std::string const& filename)
+		INIFile(mINIFilePath filename)
 		: filename(filename)
 		{ }
 

--- a/src/mini/ini.h
+++ b/src/mini/ini.h
@@ -94,14 +94,20 @@
 #include <sys/stat.h>
 #include <cctype>
 
-#ifdef _WIN32
-typedef std::wstring mINIFilePath;
-#else
-typedef std::string mINIFilePath;
-#endif
-
 namespace mINI
 {
+	struct mINIFilePath 
+	{
+		std::filesystem::path value;
+		explicit mINIFilePath(std::filesystem::path const& p) : value(p) {}
+
+		static mINIFilePath fromString(std::string const& str)
+		{
+			mINIFilePath path { str };
+			return path;
+		}
+	};
+
 	namespace INIStringUtil
 	{
 		const char* const whitespaceDelimiters = " \t\n\r\f\v";
@@ -400,14 +406,9 @@ namespace mINI
 		}
 
 	public:
-		INIReader(mINIFilePath const& filename, bool keepLineData = false)
-		{
-			fileReadStream.open(filename, std::ios::in | std::ios::binary);
-			if (keepLineData)
-			{
-				lineData = std::make_shared<T_LineData>();
-			}
-		}
+		INIReader(mINIFilePath const& filename, bool keepLineData = false) { initialize(filename, keepLineData); };
+		INIReader(std::string const& filename, bool keepLineData = false) { initialize(mINIFilePath::fromString(filename), keepLineData); };
+
 		~INIReader() { }
 
 		bool operator>>(INIStructure& data)
@@ -449,6 +450,16 @@ namespace mINI
 		{
 			return lineData;
 		}
+
+	private:
+		void initialize(mINIFilePath const& filename, bool keepLineData)
+		{
+			fileReadStream.open(filename.value, std::ios::in | std::ios::binary);
+			if (keepLineData)
+			{
+				lineData = std::make_shared<T_LineData>();
+			}
+		}
 	};
 
 	class INIGenerator
@@ -459,10 +470,16 @@ namespace mINI
 	public:
 		bool prettyPrint = false;
 
-		INIGenerator(mINIFilePath filename)
+		INIGenerator(mINIFilePath const& filename)
+		{
+			fileWriteStream.open(filename.value, std::ios::out | std::ios::binary);
+		}
+
+		INIGenerator(std::string const& filename)
 		{
 			fileWriteStream.open(filename, std::ios::out | std::ios::binary);
 		}
+
 		~INIGenerator() { }
 
 		bool operator<<(INIStructure const& data)
@@ -686,22 +703,21 @@ namespace mINI
 	public:
 		bool prettyPrint = false;
 
-		INIWriter(mINIFilePath const& filename)
+		INIWriter(std::string const& filename)
 		: filename(filename)
 		{
 		}
+		INIWriter(mINIFilePath const& filename)
+			: filename(filename)
+		{
+		}
+
 		~INIWriter() { }
 
 		bool operator<<(INIStructure& data)
 		{
-#ifdef _WIN32
-			struct _stat64i32 buf;
-			bool fileExists = (_wstat(filename.c_str(), &buf) == 0);
-#else
-			struct stat buf;
-			bool fileExists = (stat(filename.c_str(), &buf) == 0);
-#endif
-
+			//struct stat buf;
+			bool fileExists = std::filesystem::exists(filename.value);  //(stat(filename.c_str(), &buf) == 0);
 			if (!fileExists)
 			{
 				INIGenerator generator(filename);
@@ -725,7 +741,7 @@ namespace mINI
 				return false;
 			}
 			T_LineData output = getLazyOutput(lineData, data, originalData);
-			std::ofstream fileWriteStream(filename, std::ios::out | std::ios::binary);
+			std::ofstream fileWriteStream(filename.value, std::ios::out | std::ios::binary);
 			if (fileWriteStream.is_open())
 			{
 				if (fileIsBOM) {
@@ -761,8 +777,10 @@ namespace mINI
 		mINIFilePath filename;
 
 	public:
-		INIFile(mINIFilePath filename)
-		: filename(filename)
+		INIFile(mINIFilePath const& filename) : filename(filename)
+		{ }
+
+		INIFile(std::string const& filename) : filename(filename)
 		{ }
 
 		~INIFile() { }
@@ -773,7 +791,7 @@ namespace mINI
 			{
 				data.clear();
 			}
-			if (filename.empty())
+			if (filename.value.empty())
 			{
 				return false;
 			}
@@ -782,7 +800,7 @@ namespace mINI
 		}
 		bool generate(INIStructure const& data, bool pretty = false) const
 		{
-			if (filename.empty())
+			if (filename.value.empty())
 			{
 				return false;
 			}
@@ -792,7 +810,7 @@ namespace mINI
 		}
 		bool write(INIStructure& data, bool pretty = false) const
 		{
-			if (filename.empty())
+			if (filename.value.empty())
 			{
 				return false;
 			}


### PR DESCRIPTION
Windows doesn't have full support for UTF-8 file paths, it expects them to be UTF-16. So, if the file path contains any unicode characters, it needs to be std::wstring instead of std::string. I added a conditional typedef to the code to define file path type as wstring on windows, and string on other OS's, and it fixed the problem.