### PR TITLE
Suggestion: Add cmake interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+project(mINI CXX)
+set(CMAKE_CXX_STANDARD 11)
+
+add_library(mINI INTERFACE)
+target_include_directories(mINI INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")


### PR DESCRIPTION
Makes the library easy to add to a cmake project.

Example usage:
```cmake
add_subdirectory("${CMAKE_SOURCE_DIR}/vendor/metayeti/mINI")

add_executable(MyProject main.cpp)
target_link_libraries(MyProject PUBLIC
  mINI
)
```