### PR TITLE
Add supporting std::filesystem::path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tests/*.ini
 /tests/*.test
 /tests/*.exe
+/tests/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.5)
 project(mINI CXX)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# Check GCC version and add -lstdc++fs if necessary
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    if (GCC_VERSION VERSION_LESS 9.1)
+        link_libraries("-lstdc++fs")
+    endif()
+endif()
 
 add_library(mINI INTERFACE)
 target_include_directories(mINI INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/src/mini/ini.h
+++ b/src/mini/ini.h
@@ -91,8 +91,8 @@
 #include <vector>
 #include <memory>
 #include <fstream>
-#include <sys/stat.h>
 #include <cctype>
+#include <filesystem>
 
 namespace mINI
 {
@@ -381,7 +381,7 @@ namespace mINI
 		}
 
 	public:
-		INIReader(std::string const& filename, bool keepLineData = false)
+		INIReader(std::filesystem::path const& filename, bool keepLineData = false)
 		{
 			fileReadStream.open(filename, std::ios::in | std::ios::binary);
 			if (keepLineData)
@@ -440,7 +440,7 @@ namespace mINI
 	public:
 		bool prettyPrint = false;
 
-		INIGenerator(std::string const& filename)
+		INIGenerator(std::filesystem::path const& filename)
 		{
 			fileWriteStream.open(filename, std::ios::out | std::ios::binary);
 		}
@@ -506,7 +506,7 @@ namespace mINI
 		using T_LineData = std::vector<std::string>;
 		using T_LineDataPtr = std::shared_ptr<T_LineData>;
 
-		std::string filename;
+		std::filesystem::path filename;
 
 		T_LineData getLazyOutput(T_LineDataPtr const& lineData, INIStructure& data, INIStructure& original)
 		{
@@ -667,7 +667,7 @@ namespace mINI
 	public:
 		bool prettyPrint = false;
 
-		INIWriter(std::string const& filename)
+		INIWriter(std::filesystem::path const& filename)
 		: filename(filename)
 		{
 		}
@@ -675,9 +675,7 @@ namespace mINI
 
 		bool operator<<(INIStructure& data)
 		{
-			struct stat buf;
-			bool fileExists = (stat(filename.c_str(), &buf) == 0);
-			if (!fileExists)
+			if (!std::filesystem::exists(filename))
 			{
 				INIGenerator generator(filename);
 				generator.prettyPrint = prettyPrint;
@@ -733,10 +731,10 @@ namespace mINI
 	class INIFile
 	{
 	private:
-		std::string filename;
+		std::filesystem::path filename;
 
 	public:
-		INIFile(std::string const& filename)
+		INIFile(std::filesystem::path const& filename)
 		: filename(filename)
 		{ }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.5)
+project(mINI_test CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXECUTABLE_SUFFIX ".test")
+
+# Check GCC version and add -lstdc++fs if necessary
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    if (GCC_VERSION VERSION_LESS 9.1)
+        link_libraries("-lstdc++fs")
+    endif()
+endif()
+
+# Collect source files
+file(GLOB SRC_FILES "test*.cpp")
+
+include_directories("lest" "../src")
+    
+# Filter to build each test exetuable
+foreach(_source IN ITEMS ${SRC_FILES})
+    get_filename_component(_source_name "${_source}" NAME_WE)
+    add_executable(${_source_name} ${_source})
+endforeach()

--- a/tests/build.bat
+++ b/tests/build.bat
@@ -1,6 +1,6 @@
 @echo off
 IF %1.==. GOTO ERR
-g++ -Wall -Wextra -std=c++17 -I./lest -I./../src -o %1.exe %1.cpp
+g++ -Wall -Wextra -std=c++17 -I./lest -I./../src -lstdc++fs -o %1.exe %1.cpp
 GOTO END
 :ERR
 echo Use: %0 [test name]

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -3,4 +3,4 @@ if [[ $# -eq 0 ]] ; then
     echo Use: $0 [test name]
 	exit 1
 fi
-g++ -Wall -Wextra -std=c++14 -I./lest -I./../src -o $1.test $1.cpp
+g++ -Wall -Wextra -std=c++17 -I./lest -I./../src -lstdc++fs -o $1.test $1.cpp

--- a/tests/building.txt
+++ b/tests/building.txt
@@ -23,3 +23,14 @@ Examples:
 To cleanup all test files:
 
   clean
+
+------------------------------------------------------------
+
+Also can use cmake to build all tests:
+
+  cmake . -B "build"
+  cmake --build "build" -j
+
+And can run all test, use:
+
+  ./runalltest.sh 

--- a/tests/runalltest.sh
+++ b/tests/runalltest.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+cd build/
+
+rm -f *.ini
+
+for test_file in *.test; do
+    ./$test_file -p > /dev/null
+    if [[ $? -ne 0 ]]; then
+        echo "Test $test_file failed."
+        exit 1
+    fi
+    echo "Test $test_file passed."
+done

--- a/tests/testpath.cpp
+++ b/tests/testpath.cpp
@@ -1,0 +1,312 @@
+﻿#include <iostream>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <tuple>
+#include <fstream>
+#include "lest.hpp"
+#include "mini/ini.h"
+
+using T_LineData = std::vector<std::string>;
+using T_INIFileData = std::tuple<std::filesystem::path, T_LineData, T_LineData>;
+
+//
+// helper functions
+//
+bool writeTestFile(T_INIFileData const& testData)
+{
+	auto const& filename = std::get<0>(testData);
+	T_LineData const& lines = std::get<1>(testData);
+	std::ofstream fileWriteStream(filename);
+	if (fileWriteStream.is_open())
+	{
+		if (lines.size())
+		{
+			auto it = lines.begin();
+			for (;;)
+			{
+				fileWriteStream << *it;
+				if (++it == lines.end())
+				{
+					break;
+				}
+				fileWriteStream << std::endl;
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
+bool verifyData(T_INIFileData const& testData)
+{
+	// compares file contents to expected data
+	std::string line;
+	auto const& filename = std::get<0>(testData);
+	T_LineData const& linesExpected = std::get<2>(testData);
+	size_t lineCount = 0;
+	size_t lineCountExpected = linesExpected.size();
+	std::ifstream fileReadStream(filename);
+	if (fileReadStream.is_open())
+	{
+		while (std::getline(fileReadStream, line))
+		{
+			if (fileReadStream.bad())
+			{
+				return false;
+			}
+			if (lineCount >= lineCountExpected)
+			{
+				std::cout << "Line count exceeds expected!" << std::endl;
+				return false;
+			}
+			std::string const& lineExpected = linesExpected[lineCount++];
+			if (line != lineExpected)
+			{
+				std::cout << "Line " << lineCount << " does not match expected!" << std::endl;
+				std::cout << "Expected: " << lineExpected << std::endl;
+				std::cout << "Is: " << line << std::endl;
+				return false;
+			}
+		}
+		if (lineCount < lineCountExpected)
+		{
+			std::cout << "Line count falls behind expected!" << std::endl;
+		}
+		return lineCount == lineCountExpected;
+	}
+	return false;
+}
+
+void outputData(mINI::INIStructure const& ini)
+{
+	for (auto const& it : ini)
+	{
+		auto const& section = it.first;
+		auto const& collection = it.second;
+		std::cout << "[" << section << "]" << std::endl;
+		for (auto const& it2 : collection)
+		{
+			auto const& key = it2.first;
+			auto const& value = it2.second;
+			std::cout << key << "=" << value << std::endl;
+		}
+		std::cout << std::endl;
+	}
+}
+
+//
+// test data
+//
+const T_INIFileData testDataStdString {
+	// filename
+	"data_stdstring.ini",
+	// original data
+	{
+		"[fruit]",
+		"bananas=1",
+		"apples=2",
+		"grapes=3",
+	},
+	// expected result
+	{
+		"[fruit]",
+		"bananas=2",
+		"apples=3",
+		"grapes=4",
+	}
+};
+
+const T_INIFileData testDataUTF16JP {
+	// filename
+	u"data_u16テスト.ini",
+	// original data
+	{
+		"[fruit]",
+		"bananas=1",
+		"apples=2",
+		"grapes=3",
+	},
+	// expected result
+	{
+		"[fruit]",
+		"bananas=2",
+		"apples=3",
+		"grapes=4",
+	}
+};
+
+const T_INIFileData testDataUTF16TC {
+	// filename
+	u"data_u16測試.ini",
+	// original data
+	{
+		"[fruit]",
+		"bananas=1",
+		"apples=2",
+		"grapes=3",
+	},
+	// expected result
+	{
+		"[fruit]",
+		"bananas=2",
+		"apples=3",
+		"grapes=4",
+	}
+};
+
+const T_INIFileData testDataUTF32JP {
+	// filename
+	U"data_u32テスト.ini",
+	// original data
+	{
+		"[fruit]",
+		"bananas=1",
+		"apples=2",
+		"grapes=3",
+	},
+	// expected result
+	{
+		"[fruit]",
+		"bananas=2",
+		"apples=3",
+		"grapes=4",
+	}
+};
+
+const T_INIFileData testDataUTF32TC {
+	// filename
+	U"data_u32測試.ini",
+	// original data
+	{
+		"[fruit]",
+		"bananas=1",
+		"apples=2",
+		"grapes=3",
+	},
+	// expected result
+	{
+		"[fruit]",
+		"bananas=2",
+		"apples=3",
+		"grapes=4",
+	}
+};
+
+//
+// test cases
+//
+const lest::test mINI_tests[] = {
+	CASE("TEST: std::string read/write")
+	{
+		// read a INI file with std::string and check if values are read correctly
+		auto const& filename = std::get<0>(testDataStdString);
+		mINI::INIFile file(filename.string());
+		mINI::INIStructure ini;
+		EXPECT(file.read(ini) == true);
+		EXPECT(ini["fruit"]["bananas"] == "1");
+		EXPECT(ini["fruit"]["apples"] == "2");
+		EXPECT(ini["fruit"]["grapes"] == "3");
+		// update data
+		ini["fruit"]["bananas"] = "2";
+		ini["fruit"]["apples"] = "3";
+		ini["fruit"]["grapes"] = "4";
+		// write to file
+		EXPECT(file.write(ini) == true);
+		// verify data
+		EXPECT(verifyData(testDataStdString));
+	},
+	CASE("TEST: utf-16 jp read/write")
+	{
+		// read a INI file with utf-16 jp path and check if values are read correctly
+		auto const& filename = std::get<0>(testDataUTF16JP);
+		mINI::INIFile file(filename);
+		mINI::INIStructure ini;
+		EXPECT(file.read(ini) == true);
+		EXPECT(ini["fruit"]["bananas"] == "1");
+		EXPECT(ini["fruit"]["apples"] == "2");
+		EXPECT(ini["fruit"]["grapes"] == "3");
+		// update data
+		ini["fruit"]["bananas"] = "2";
+		ini["fruit"]["apples"] = "3";
+		ini["fruit"]["grapes"] = "4";
+		// write to file
+		EXPECT(file.write(ini) == true);
+		// verify data
+		EXPECT(verifyData(testDataUTF16JP));
+	},
+	CASE("TEST: utf-16 tc read/write")
+	{
+		// read a INI file with utf-16 tc path and check if values are read correctly
+		auto const& filename = std::get<0>(testDataUTF16TC);
+		mINI::INIFile file(filename);
+		mINI::INIStructure ini;
+		EXPECT(file.read(ini) == true);
+		EXPECT(ini["fruit"]["bananas"] == "1");
+		EXPECT(ini["fruit"]["apples"] == "2");
+		EXPECT(ini["fruit"]["grapes"] == "3");
+		// update data
+		ini["fruit"]["bananas"] = "2";
+		ini["fruit"]["apples"] = "3";
+		ini["fruit"]["grapes"] = "4";
+		// write to file
+		EXPECT(file.write(ini) == true);
+		// verify data
+		EXPECT(verifyData(testDataUTF16TC));
+	},
+	CASE("TEST: utf-32 jp read/write")
+	{
+		// read a INI file with utf-32 jp path and check if values are read correctly
+		auto const& filename = std::get<0>(testDataUTF32JP);
+		mINI::INIFile file(filename);
+		mINI::INIStructure ini;
+		EXPECT(file.read(ini) == true);
+		EXPECT(ini["fruit"]["bananas"] == "1");
+		EXPECT(ini["fruit"]["apples"] == "2");
+		EXPECT(ini["fruit"]["grapes"] == "3");
+		// update data
+		ini["fruit"]["bananas"] = "2";
+		ini["fruit"]["apples"] = "3";
+		ini["fruit"]["grapes"] = "4";
+		// write to file
+		EXPECT(file.write(ini) == true);
+		// verify data
+		EXPECT(verifyData(testDataUTF32JP));
+	},
+	CASE("TEST: utf-32 tc read/write")
+	{
+		// read a INI file with utf-32 tc path and check if values are read correctly
+		auto const& filename = std::get<0>(testDataUTF32TC);
+		mINI::INIFile file(filename);
+		mINI::INIStructure ini;
+		EXPECT(file.read(ini) == true);
+		EXPECT(ini["fruit"]["bananas"] == "1");
+		EXPECT(ini["fruit"]["apples"] == "2");
+		EXPECT(ini["fruit"]["grapes"] == "3");
+		// update data
+		ini["fruit"]["bananas"] = "2";
+		ini["fruit"]["apples"] = "3";
+		ini["fruit"]["grapes"] = "4";
+		// write to file
+		EXPECT(file.write(ini) == true);
+		// verify data
+		EXPECT(verifyData(testDataUTF32TC));
+	},
+};
+
+int main(int argc, char** argv)
+{
+	// write test files
+	writeTestFile(testDataStdString);
+	writeTestFile(testDataUTF16JP);
+	writeTestFile(testDataUTF16TC);
+	writeTestFile(testDataUTF32JP);
+	writeTestFile(testDataUTF32TC);
+	
+	// run tests
+	if (int failures = lest::run(mINI_tests, argc, argv))
+	{
+		return failures;
+	}
+	return std::cout << std::endl << "All tests passed!" << std::endl, EXIT_SUCCESS;
+}


### PR DESCRIPTION
Support std::filesystem::path, also add testing and cmake. I tested in Ubuntu 24.04 with gcc 13, also 20.04 with gcc 9.4.0 and 8.X. I already use this simplest change from 0.9.10, and used in VS2017~2022/macOS.