### PR TITLE
Update target_include_directories to support build and install interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 add_library(mINI INTERFACE)
-target_include_directories(mINI INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+target_include_directories(mINI INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include/mINI>)


### PR DESCRIPTION
This occurred because the INTERFACE include directories were using absolute source paths that are invalid when the target is exported/installed to other systems.

## Solution
- Updated `target_include_directories` to use CMake generator expressions
- Used `$<BUILD_INTERFACE:...>` for build-time include paths
- Used `$<INSTALL_INTERFACE:...>` for install-time include paths
- This ensures the target can be properly exported and used by external projects

## Changes
- Modified CMakeLists.txt to use proper generator expressions for include directories
- Ensured compatibility with CMake's export/install mechanisms
- Maintained backward compatibility for local builds

## Testing
- [x] Local build completes successfully
- [x] CMake generation passes without errors
- [x] Target can be properly exported

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)